### PR TITLE
fix(ui): clear terminal before whiptail and cap list_height to item count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Fixed
 
+- **Whiptail checklist double-box visual artifact** (`docs/install.sh`, `lib/ui.sh`): the checklist dialog appeared to render two overlapping dialog boxes because previous terminal output (dnf progress, log messages) remained on screen when whiptail drew its dialog. Fixed by calling `clear` immediately before the `tui_checklist` call so whiptail renders onto a clean terminal. Also capped `list_height` at the actual item count (previously `height - 8` could exceed the number of items on a large terminal, causing whiptail to allocate more list rows than items, which shifts the dialog geometry and can produce rendering glitches on some terminal sizes).
+
 - **Unsupported target flow**: `docs/install.sh` now downloads the repo and runs full target detection before `sudo -v`, so unsupported machines exit with the friendly message before any privilege prompt.
 - **mbpfan source fallback**: when Fedora does not provide `mbpfan`, the source build now clones the maintained `linux-on-mac/mbpfan` repo, installs the systemd unit explicitly, and warns instead of aborting the whole run if the optional fallback fails.
 - **TLP service conflict handling**: TLP setup now stops/disables and masks `power-profiles-daemon.service` before enabling `tlp.service`, preventing the conflicting daemon from continuing in the current boot.

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -208,7 +208,9 @@ for entry in "${EXTRAS_MANIFEST[@]}"; do
     CHECKLIST_ARGS+=("$key" "$desc" "$default")
 done
 
-log "Showing extras menu…"
+# Clear the terminal before whiptail so dnf/log output from prior steps
+# doesn't appear behind the dialog as a false second dialog-border.
+clear 2>/dev/null || true
 SELECTED=$(tui_checklist "Optional extras for $TARGET" \
     "Critical drivers will be installed automatically.\nPick which optional extras you want:" \
     "${CHECKLIST_ARGS[@]}") || die "Aborted at extras selection." 0

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -105,12 +105,17 @@ tui_checklist() {
     done
     if has_cmd whiptail; then
         # Fit the dialog to the actual terminal; cap at comfortable maximums.
-        local cols rows width height list_height
+        local cols rows width height list_height num_items
         cols=$(tput cols 2>/dev/null || echo 80)
         rows=$(tput lines 2>/dev/null || echo 24)
         width=$(( cols - 4 ));  [ "$width" -gt 76 ] && width=76
         height=$(( rows - 4 )); [ "$height" -gt 20 ] && height=20
-        list_height=$(( height - 8 )); [ "$list_height" -lt 3 ] && list_height=3
+        num_items=$(( ${#items[@]} / 3 ))
+        list_height=$(( height - 8 ))
+        # Cap at actual item count — prevents the dialog being taller than needed,
+        # which causes whiptail to overflow/render incorrectly on small terminals.
+        [ "$list_height" -gt "$num_items" ] && list_height=$num_items
+        [ "$list_height" -lt 3 ] && list_height=3
 
         # whiptail writes the selection to stderr (because stdout is for the UI),
         # so redirect 3>&1 1>&2 2>&3 to swap them.


### PR DESCRIPTION
Previous dnf/log output remained on screen when whiptail rendered its
dialog, making ASCII table borders from package-install progress appear
as a false second dialog box behind the checklist.

Two root causes fixed:
1. docs/install.sh: call `clear` immediately before tui_checklist so
   whiptail always renders onto a clean terminal.
2. lib/ui.sh: cap list_height at the actual item count. On large
   terminals height-8 exceeded the number of items, giving whiptail
   more list rows than it had items to fill, which shifted the dialog
   geometry and triggered rendering glitches on some terminal sizes.

https://claude.ai/code/session_0128hMYdNNHtPRsbFUth4Bhj