### PR TITLE
fix(camera): dkms autoinstall, firmware verification, and module persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 - **Curl vs wget on landing page**: ship both one-liners. Some Debian-family minimal installs lack curl; some have only wget. Modern Fedora Workstation has curl by default.
 - **Memory system**: project-specific knowledge goes in CLAUDE.md, not in any agent's local memory. Confirmed with user.
 
+- **FaceTime HD camera not working after install (`install_facetimehd`)**: three compounding problems. (1) `dkms autoinstall` was never called after installing `facetimehd-dkms`, so the kernel module was not built for the running kernel — only for the next boot if DKMS ran automatically. (2) The `facetimehd-firmware` RPM's `%post` scriptlet downloads the firmware binary from Apple's CDN; if that network request fails the firmware is silently missing and the camera shows "No Camera Found" even if the module loads. Fixed by checking `/usr/lib/firmware/facetimehd/firmware.bin` after install and looking for any packaged re-download helper, then warning explicitly with the manual URL if firmware is still absent. (3) There was no `/etc/modules-load.d/facetimehd.conf` entry, so even a successfully loaded module would not persist across reboots. All three gaps now addressed.
+
 ### Known issues / to verify on real hardware
 
 - End-to-end run on a clean MBA7,2 + Fedora 44 install has not yet happened. Manual test checklist lives in CLAUDE.md §7.

--- a/targets/macbookair7_2-fedora44/extras.sh
+++ b/targets/macbookair7_2-fedora44/extras.sh
@@ -95,13 +95,46 @@ install_gnome_tweaks() {
 # ---------------- 6. FaceTime HD camera (fragile, off by default) -----------
 install_facetimehd() {
     log "Installing FaceTime HD camera driver…"
-    warn "FaceTime HD setup is the most fragile part of this script."
-    warn "If it fails, manual route: https://github.com/patjak/facetimehd/wiki/Get-Started"
-    if dnf copr enable -y mulderje/facetimehd-dkms 2>/dev/null; then
-        dnf install -y facetimehd-firmware facetimehd-dkms || warn "Camera package install failed"
-        modprobe facetimehd 2>/dev/null || warn "facetimehd module didn't load — try after reboot"
-        mark_reboot "FaceTime HD camera (kernel module)"
-    else
-        warn "COPR not available for this Fedora version — skipping FaceTime HD"
+    warn "FaceTime HD setup is fragile. Manual route: https://github.com/patjak/facetimehd/wiki/Get-Started"
+
+    if ! dnf copr enable -y mulderje/facetimehd-dkms 2>/dev/null; then
+        warn "COPR not available for Fedora $(rpm -E %fedora) — skipping FaceTime HD"
+        return 0
     fi
+
+    if ! dnf install -y facetimehd-firmware facetimehd-dkms; then
+        warn "Camera package install failed — skipping FaceTime HD"
+        return 0
+    fi
+
+    # Build the DKMS module for the running kernel right now, not just on next boot.
+    dkms autoinstall 2>/dev/null || warn "DKMS autoinstall had errors — module may still build on next boot"
+
+    # The facetimehd-firmware %post scriptlet downloads firmware from Apple CDN.
+    # It silently fails if the network request fails. Verify and warn explicitly.
+    local fw_path="/usr/lib/firmware/facetimehd/firmware.bin"
+    if [ ! -f "$fw_path" ]; then
+        # The package may ship a helper script to re-run the firmware download.
+        local fw_script
+        fw_script=$(find /usr/lib/facetimehd /usr/share/facetimehd /usr/sbin \
+                         -maxdepth 1 -name "*firmware*" -executable 2>/dev/null | head -1)
+        if [ -n "$fw_script" ]; then
+            log "Re-running firmware download script: $fw_script"
+            "$fw_script" 2>/dev/null || true
+        fi
+    fi
+
+    if [ -f "$fw_path" ]; then
+        ok "FaceTime HD firmware present at $fw_path"
+    else
+        warn "Firmware not found at $fw_path — camera will not work."
+        warn "After reboot, run the firmware helper manually or follow:"
+        warn "  https://github.com/patjak/facetimehd/wiki/Get-Started#firmware"
+    fi
+
+    # Ensure the module loads on every boot, not just the current session.
+    echo "facetimehd" > /etc/modules-load.d/facetimehd.conf
+
+    modprobe facetimehd 2>/dev/null || warn "facetimehd module not loadable yet — should work after reboot"
+    mark_reboot "FaceTime HD camera (kernel module + firmware)"
 }


### PR DESCRIPTION
Three compounding reasons the FaceTime HD camera showed "No Camera Found"
after running the script:

1. dkms autoinstall was never called — the kernel module wasn't built for
   the running kernel, only queued for the next boot.
2. facetimehd-firmware's %post downloads firmware from Apple CDN and fails
   silently on network errors — added explicit firmware check with a fallback
   that searches for any packaged re-download helper script.
3. No /etc/modules-load.d/facetimehd.conf entry — the module wouldn't
   persist across reboots even if successfully loaded.

https://claude.ai/code/session_01CwuTDui47oAwDoNxZB6pL4